### PR TITLE
Implement tank controls for player movement based on aim direction

### DIFF
--- a/src/core/game.py
+++ b/src/core/game.py
@@ -442,9 +442,11 @@ class Game:
             return
 
         keys = pygame.key.get_pressed()
-        self.player.handle_input(keys)
-        # Прицел независим от WASD - следует за мышью каждый кадр (twin-stick).
+        # Прицел (мышь) - до handle_input: W/A/S/D двигают игрока относительно
+        # текущего направления взгляда (см. Player.handle_input), поэтому aim
+        # должен быть уже актуален на этот кадр, а не с прошлого.
         self.player.update_aim(self.world.camera_x, self.world.camera_y)
+        self.player.handle_input(keys)
         self.player.update(dt, self.world, self.game_stats)
 
         # Враги патрулируют свои зоны + авто-респавн при удалении игрока

--- a/src/entities/player.py
+++ b/src/entities/player.py
@@ -20,8 +20,11 @@ class Player:
         self.sprint_multiplier = get_config('PLAYER_SPRINT_MULTIPLIER')
         self.is_sprinting = False
 
-        # Направление движения (WASD) - полностью независимо от прицела/атаки
-        # (twin-stick: "как турель" - движешься куда угодно, целишься мышью).
+        # Направление движения - результат W/A/S/D относительно направления
+        # прицела (см. handle_input): вперёд/назад вдоль (aim_dx, aim_dy),
+        # влево/вправо перпендикулярно ему. Не twin-stick - игрок вращается
+        # на месте прицелом (мышь), а движение всегда "танковое" относительно
+        # того, куда он сейчас смотрит.
         self.direction_x = 0
         self.direction_y = 0
 
@@ -249,8 +252,12 @@ class Player:
             return False
 
     def handle_input(self, keys):
-        """Обработка ввода с клавиатуры (движение). Прицел/атака направлением
-        мыши считаются отдельно в update_aim() - не здесь."""
+        """Обработка ввода с клавиатуры (движение). Атака направлением мыши
+        считается отдельно в update_aim() - но именно её результат
+        (aim_dx, aim_dy) задаёт оси движения W/A/S/D ниже: игрок вращается
+        на месте прицелом, а W/S двигают его вперёд/назад вдоль этого
+        направления, A/D - вбок (strafe), перпендикулярно ему. Стрелки
+        движение не дают - только WASD."""
         # Сброс направления
         self.direction_x = 0
         self.direction_y = 0
@@ -261,20 +268,29 @@ class Player:
             or self._is_key_pressed(keys, pygame.K_RSHIFT)
         )
 
-        # Движение по 8 направлениям - независимо от прицела (twin-stick)
-        if keys[pygame.K_LEFT] or keys[pygame.K_a]:
-            self.direction_x = -1
-        if keys[pygame.K_RIGHT] or keys[pygame.K_d]:
-            self.direction_x = 1
-        if keys[pygame.K_UP] or keys[pygame.K_w]:
-            self.direction_y = -1
-        if keys[pygame.K_DOWN] or keys[pygame.K_s]:
-            self.direction_y = 1
+        # W/S - вперёд/назад вдоль вектора прицела (aim_dx, aim_dy).
+        forward = 0
+        if keys[pygame.K_w]:
+            forward += 1
+        if keys[pygame.K_s]:
+            forward -= 1
+        # A/D - вбок (strafe), перпендикулярно прицелу. "Вправо" при взгляде
+        # (aim_dx, aim_dy) - вектор (-aim_dy, aim_dx) (экранные координаты,
+        # y вниз: поворот на 90° по часовой стрелке от взгляда игрока).
+        strafe = 0
+        if keys[pygame.K_d]:
+            strafe += 1
+        if keys[pygame.K_a]:
+            strafe -= 1
 
-        # Нормализация диагонального движения
-        if self.direction_x != 0 and self.direction_y != 0:
-            self.direction_x *= 0.707  # 1/sqrt(2)
-            self.direction_y *= 0.707
+        # Нормализация диагонального движения (W+A/W+D/S+A/S+D)
+        if forward != 0 and strafe != 0:
+            forward *= 0.707  # 1/sqrt(2)
+            strafe *= 0.707
+
+        right_dx, right_dy = -self.aim_dy, self.aim_dx
+        self.direction_x = forward * self.aim_dx + strafe * right_dx
+        self.direction_y = forward * self.aim_dy + strafe * right_dy
 
         # Атака на пробел (в текущем направлении прицела - см. update_aim)
         if keys[pygame.K_SPACE]:

--- a/tests/unit/test_player.py
+++ b/tests/unit/test_player.py
@@ -47,48 +47,58 @@ class TestPlayer:
         assert self.player.attacking == False
         assert isinstance(self.player.rect, pygame.Rect)
         
-    def test_player_movement_input(self):
-        """Test player handles movement input correctly"""
-        # Mock keys pressed
-        keys = {
-            pygame.K_LEFT: False,
-            pygame.K_RIGHT: True,
-            pygame.K_UP: False,
-            pygame.K_DOWN: False,
-            pygame.K_a: False,
-            pygame.K_d: False,
-            pygame.K_w: False,
-            pygame.K_s: False,
-            pygame.K_SPACE: False
-        }
-        
+    def test_player_movement_forward_follows_aim(self):
+        """W двигает игрока вперёд - вдоль текущего направления прицела,
+        не по фиксированной мировой оси (танковое управление)."""
+        self.player.aim_dx, self.player.aim_dy = 1.0, 0.0  # смотрим вправо
+        keys = self._press(pygame.K_w)
         self.player.handle_input(keys)
+        assert self.player.direction_x == pytest.approx(1.0)
+        assert self.player.direction_y == pytest.approx(0.0)
 
-        assert self.player.direction_x == 1
-        assert self.player.direction_y == 0
-        # facing_direction больше не выводится из WASD - см. update_aim()
-        # (мышь, "как турель") - движение и прицел независимы.
-        
-    def test_player_diagonal_movement(self):
-        """Test player diagonal movement normalization"""
-        keys = {
-            pygame.K_LEFT: False,
-            pygame.K_RIGHT: True,
-            pygame.K_UP: True,
-            pygame.K_DOWN: False,
-            pygame.K_a: False,
-            pygame.K_d: False,
-            pygame.K_w: False,
-            pygame.K_s: False,
-            pygame.K_SPACE: False
-        }
-        
+    def test_player_movement_backward_is_opposite_of_aim(self):
+        """S - пятится назад, противоположно направлению прицела."""
+        self.player.aim_dx, self.player.aim_dy = 1.0, 0.0
+        keys = self._press(pygame.K_s)
         self.player.handle_input(keys)
-        
-        # Check diagonal movement is normalized
-        assert abs(self.player.direction_x - 0.707) < 0.01
-        assert abs(self.player.direction_y - (-0.707)) < 0.01
-        
+        assert self.player.direction_x == pytest.approx(-1.0)
+        assert self.player.direction_y == pytest.approx(0.0)
+
+    def test_player_strafe_right_is_perpendicular_to_aim(self):
+        """D - вбок вправо относительно взгляда: смотрим вправо (1,0) ->
+        "вправо от игрока" на экране (y вниз) - это (0,1), т.е. вниз."""
+        self.player.aim_dx, self.player.aim_dy = 1.0, 0.0
+        keys = self._press(pygame.K_d)
+        self.player.handle_input(keys)
+        assert self.player.direction_x == pytest.approx(0.0)
+        assert self.player.direction_y == pytest.approx(1.0)
+
+    def test_player_strafe_left_is_opposite_of_strafe_right(self):
+        """A - вбок влево, противоположно D."""
+        self.player.aim_dx, self.player.aim_dy = 1.0, 0.0
+        keys = self._press(pygame.K_a)
+        self.player.handle_input(keys)
+        assert self.player.direction_x == pytest.approx(0.0)
+        assert self.player.direction_y == pytest.approx(-1.0)
+
+    def test_player_diagonal_movement(self):
+        """W+D одновременно - нормализованная диагональ (вперёд+вбок),
+        как раньше для мировых осей, но теперь относительно прицела."""
+        self.player.aim_dx, self.player.aim_dy = 1.0, 0.0
+        keys = self._press(pygame.K_w, pygame.K_d)
+        self.player.handle_input(keys)
+        assert self.player.direction_x == pytest.approx(0.707, abs=0.01)
+        assert self.player.direction_y == pytest.approx(0.707, abs=0.01)
+
+    def test_arrow_keys_do_not_move_player(self):
+        """Стрелки больше не двигают игрока - только WASD (относительно
+        прицела)."""
+        keys = self._press(pygame.K_LEFT, pygame.K_RIGHT,
+                           pygame.K_UP, pygame.K_DOWN)
+        self.player.handle_input(keys)
+        assert self.player.direction_x == 0
+        assert self.player.direction_y == 0
+
     def test_player_attack_input(self):
         """Test player attack input"""
         keys = {
@@ -358,19 +368,15 @@ class TestPlayer:
         self._aim_at_screen_offset(0, 0)  # курсор точно на игроке
         assert (self.player.aim_dx, self.player.aim_dy) == (prev_dx, prev_dy)
 
-    def test_movement_independent_of_aim(self):
-        """Twin-stick: WASD не должен трогать aim_dx/aim_dy вообще."""
+    def test_movement_does_not_change_aim(self):
+        """Танковое управление: WASD зависит от прицела (aim_dx/aim_dy), но
+        не наоборот - handle_input не должен трогать aim_dx/aim_dy вообще,
+        им управляет только update_aim() (мышь)."""
         self._aim_at_screen_offset(100, 0)  # целимся вправо
-        keys = {
-            pygame.K_LEFT: True, pygame.K_RIGHT: False,
-            pygame.K_UP: False, pygame.K_DOWN: False,
-            pygame.K_a: False, pygame.K_d: False,
-            pygame.K_w: False, pygame.K_s: False,
-            pygame.K_SPACE: False,
-        }
-        self.player.handle_input(keys)  # двигаемся влево
-        assert self.player.direction_x == -1
-        # Прицел не изменился, несмотря на движение в другую сторону
+        keys = self._press(pygame.K_w)
+        self.player.handle_input(keys)  # двигаемся вперёд (по прицелу)
+        assert self.player.direction_x == pytest.approx(1.0)
+        # Прицел не изменился от самого факта движения
         assert self.player.aim_dx == pytest.approx(1.0, abs=0.01)
 
     def test_player_health_minimum_zero(self):
@@ -535,23 +541,27 @@ class TestPlayer:
 
     def test_sprint_speed_multiplier_applied(self):
         """При зажатом Shift игрок реально движется быстрее."""
+        # Целимся вверх, чтобы D (strafe вправо) двигал игрока на восток
+        # (+x) - подальше от границ мира 1000x1000, иначе clamp у стенки
+        # маскирует разницу в скорости между обычным и sprint-движением.
+        self.player.aim_dx, self.player.aim_dy = 0.0, -1.0
         # Без спринта - проходим X пикселей за 1 секунду
-        self.player.x = 100
-        self.player.y = 100
+        self.player.x = 500
+        self.player.y = 500
         self.player.handle_input(self._press(pygame.K_d))  # вправо
         self.player.update(dt=1.0, world=self.mock_world)
         normal_x = self.player.x
 
         # Сброс позиции и тот же ввод + Shift
-        self.player.x = 100
-        self.player.y = 100
+        self.player.x = 500
+        self.player.y = 500
         self.player.handle_input(self._press(pygame.K_d, pygame.K_LSHIFT))
         self.player.update(dt=1.0, world=self.mock_world)
         sprint_x = self.player.x
 
         # Должно быть ровно в sprint_multiplier раз дальше
-        normal_dist = normal_x - 100
-        sprint_dist = sprint_x - 100
+        normal_dist = normal_x - 500
+        sprint_dist = sprint_x - 500
         ratio = sprint_dist / normal_dist
         assert abs(ratio - self.player.sprint_multiplier) < 0.001, (
             f"Sprint ratio {ratio} != multiplier {self.player.sprint_multiplier}"


### PR DESCRIPTION
This pull request refactors the player's movement system from a twin-stick (independent movement and aiming) to a "tank-style" control scheme, where movement via WASD is always relative to the current aim direction (controlled by the mouse). The changes ensure that forward/backward movement is along the aim vector, strafing is perpendicular, and arrow keys no longer move the player. The tests are updated to reflect and verify the new behavior.

**Player movement system overhaul:**

* The player's movement (`WASD`) is now relative to the aim direction (`aim_dx`, `aim_dy`), not the world axes. Forward/backward move along the aim vector; strafing is perpendicular to it. Arrow keys no longer move the player. (`src/entities/player.py`) [[1]](diffhunk://#diff-f649f8575d39650b44968cd2cb23a8ad14a7ac184edfb423080b8238404b5c24L23-R27) [[2]](diffhunk://#diff-f649f8575d39650b44968cd2cb23a8ad14a7ac184edfb423080b8238404b5c24L252-R260) [[3]](diffhunk://#diff-f649f8575d39650b44968cd2cb23a8ad14a7ac184edfb423080b8238404b5c24L264-R293)
* The update loop in `game.py` ensures the aim is updated before handling movement input, so movement always uses the latest aim direction. (`src/core/game.py`)

**Testing updates:**

* Unit tests are rewritten to check that movement is correctly relative to the aim, that diagonal movement is normalized, and that arrow keys do not move the player. (`tests/unit/test_player.py`)
* Tests confirm that movement input does not affect the aim direction, only the mouse does. (`tests/unit/test_player.py`)
* Sprint speed test is adjusted for the new movement logic, ensuring consistent results regardless of world boundaries. (`tests/unit/test_player.py`)