### PR TITLE
feat(menu): enhance menu input handling with mouse support

### DIFF
--- a/src/core/game.py
+++ b/src/core/game.py
@@ -167,6 +167,13 @@ class Game:
                 self._handle_inventory_event(event)
                 continue
 
+            # Главное меню - наведение/клик мышью по пунктам.
+            if self.state == GameState.MENU and event.type in (
+                pygame.MOUSEMOTION, pygame.MOUSEBUTTONDOWN
+            ):
+                self._handle_menu_input(event)
+                continue
+
             # ЛКМ дополнительно к Space атакует в текущем направлении прицела
             # (прицел следует за мышью - см. Player.update_aim). Пробел
             # по-прежнему работает как раньше, это не замена, а альтернатива.
@@ -184,7 +191,7 @@ class Game:
                 continue
 
             if self.state == GameState.MENU:
-                self._handle_menu_key(event)
+                self._handle_menu_input(event)
             elif self.state == GameState.PLAYING:
                 self._handle_playing_key(event)
             elif self.state == GameState.GAME_OVER:
@@ -192,7 +199,7 @@ class Game:
             elif self.state in (GameState.LOAD_MENU, GameState.SAVE_MENU):
                 self._handle_save_load_menu_key(event)
 
-    def _handle_menu_key(self, event):
+    def _handle_menu_input(self, event):
         action = self.menu.handle_input(event)
         if action == "new_game":
             self.start_new_game()

--- a/src/ui/menu.py
+++ b/src/ui/menu.py
@@ -71,8 +71,21 @@ class MainMenu:
         if self.selected_index >= len(self.menu_items):
             self.selected_index = len(self.menu_items) - 1
     
+    def _menu_item_rects(self):
+        """Прямоугольники пунктов меню для хит-тестинга мыши.
+
+        Геометрия должна совпадать с раскладкой в draw().
+        """
+        width = get_config('WIDTH')
+        menu_start_y = 250
+        rects = []
+        for i in range(len(self.menu_items)):
+            y_pos = menu_start_y + i * 70
+            rects.append(pygame.Rect(width // 2 - 150, y_pos - 25, 300, 50))
+        return rects
+
     def handle_input(self, event):
-        """Обработка ввода в меню"""
+        """Обработка ввода в меню (клавиатура и мышь)"""
         if event.type == pygame.KEYDOWN:
             if event.key == pygame.K_UP:
                 self.selected_index = (self.selected_index - 1) % len(self.menu_items)
@@ -80,6 +93,16 @@ class MainMenu:
                 self.selected_index = (self.selected_index + 1) % len(self.menu_items)
             elif event.key == pygame.K_RETURN:
                 return self.get_selected_action()
+        elif event.type == pygame.MOUSEMOTION:
+            for i, rect in enumerate(self._menu_item_rects()):
+                if rect.collidepoint(event.pos):
+                    self.selected_index = i
+                    break
+        elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            for i, rect in enumerate(self._menu_item_rects()):
+                if rect.collidepoint(event.pos):
+                    self.selected_index = i
+                    return self.get_selected_action()
         return None
     
     def get_selected_action(self):
@@ -122,15 +145,15 @@ class MainMenu:
         
         # Пункты меню с улучшенной стилизацией
         menu_start_y = 250
+        item_rects = self._menu_item_rects()
         for i, item in enumerate(self.menu_items):
             y_pos = menu_start_y + i * 70
-            
+
             # Цвет и эффекты для выбранного пункта
             if i == self.selected_index:
                 color = get_color('YELLOW')
                 # Рамка вокруг выбранного пункта
-                menu_rect = pygame.Rect(get_config('WIDTH') // 2 - 150, y_pos - 25, 300, 50)
-                pygame.draw.rect(screen, get_color('DARK_GRAY'), menu_rect, 2)
+                pygame.draw.rect(screen, get_color('DARK_GRAY'), item_rects[i], 2)
                 # Стрелочки для выбранного пункта
                 arrow_font = pygame.font.Font(None, 48)
                 left_arrow = arrow_font.render("►", True, get_color('YELLOW'))
@@ -148,7 +171,7 @@ class MainMenu:
         # Инструкции внизу экрана
         instruction_font = pygame.font.Font(None, 24)
         instructions = [
-            "↑↓ - Навигация по меню",
+            "↑↓ - Навигация по меню, мышь - наведение и клик",
             "Enter - Выбрать",
             "ESC - Выход (в игре - возврат в меню)"
         ]

--- a/tests/unit/test_menu_system.py
+++ b/tests/unit/test_menu_system.py
@@ -211,6 +211,67 @@ class TestMainMenu(unittest.TestCase):
         action = menu.handle_input(event)
         self.assertEqual(action, "load_game")
     
+    def test_mouse_motion_hover_selects_item(self):
+        """Наведение мыши на пункт меню обновляет selected_index"""
+        menu = MainMenu()
+        with patch('src.ui.menu.get_config') as mock_get_config:
+            mock_get_config.side_effect = lambda key: {'WIDTH': 800, 'HEIGHT': 600}.get(key, 0)
+            rects = menu._menu_item_rects()
+            target_index = len(menu.menu_items) - 1
+
+            event = MagicMock()
+            event.type = pygame.MOUSEMOTION
+            event.pos = rects[target_index].center
+
+            menu.handle_input(event)
+        self.assertEqual(menu.selected_index, target_index)
+
+    def test_mouse_motion_outside_items_keeps_selection(self):
+        """Движение мыши вне пунктов меню не меняет выбор"""
+        menu = MainMenu()
+        menu.selected_index = 0
+
+        with patch('src.ui.menu.get_config') as mock_get_config:
+            mock_get_config.side_effect = lambda key: {'WIDTH': 800, 'HEIGHT': 600}.get(key, 0)
+            event = MagicMock()
+            event.type = pygame.MOUSEMOTION
+            event.pos = (0, 0)
+
+            menu.handle_input(event)
+        self.assertEqual(menu.selected_index, 0)
+
+    def test_mouse_click_selects_and_activates_item(self):
+        """Клик ЛКМ по пункту меню выбирает его и возвращает действие"""
+        menu = MainMenu()
+        with patch('src.ui.menu.get_config') as mock_get_config:
+            mock_get_config.side_effect = lambda key: {'WIDTH': 800, 'HEIGHT': 600}.get(key, 0)
+            rects = menu._menu_item_rects()
+            exit_index = menu.menu_items.index("Выход")
+
+            event = MagicMock()
+            event.type = pygame.MOUSEBUTTONDOWN
+            event.button = 1
+            event.pos = rects[exit_index].center
+
+            action = menu.handle_input(event)
+        self.assertEqual(menu.selected_index, exit_index)
+        self.assertEqual(action, "exit")
+
+    def test_mouse_right_click_ignored(self):
+        """ПКМ по пункту меню не активирует его"""
+        menu = MainMenu()
+        with patch('src.ui.menu.get_config') as mock_get_config:
+            mock_get_config.side_effect = lambda key: {'WIDTH': 800, 'HEIGHT': 600}.get(key, 0)
+            rects = menu._menu_item_rects()
+
+            event = MagicMock()
+            event.type = pygame.MOUSEBUTTONDOWN
+            event.button = 3
+            event.pos = rects[0].center
+
+            action = menu.handle_input(event)
+        self.assertIsNone(action)
+
     def test_invalid_event_handling(self):
         """Тест обработки неподдерживаемых событий"""
         menu = MainMenu()


### PR DESCRIPTION
This pull request adds mouse support to the main menu, allowing users to navigate and select menu items using the mouse in addition to the keyboard. The menu now highlights items on mouse hover and activates them on left-click. The changes also include updated instructions and comprehensive unit tests for the new mouse interactions.

**Menu interaction improvements:**

* Added mouse hover and left-click support to the main menu: moving the mouse over menu items highlights them, and left-click selects and activates the item (`src/ui/menu.py`, `src/core/game.py`). [[1]](diffhunk://#diff-b25208f3db4e081d78c1133b733c2924f96ac0f4046dd43bdb174ac02ae17ef4R74-R105) [[2]](diffhunk://#diff-10ac701124167d2efb3bd3173694ec60a4d099fe087c946fca31c9c416cf0592R170-R176) [[3]](diffhunk://#diff-10ac701124167d2efb3bd3173694ec60a4d099fe087c946fca31c9c416cf0592L187-R202)
* Updated menu instructions to inform users about mouse navigation and selection (`src/ui/menu.py`).

**Rendering updates:**

* Refactored menu item rectangle calculation to ensure mouse hit-testing matches the visual layout, and reused these rectangles for both rendering and interaction (`src/ui/menu.py`). [[1]](diffhunk://#diff-b25208f3db4e081d78c1133b733c2924f96ac0f4046dd43bdb174ac02ae17ef4R74-R105) [[2]](diffhunk://#diff-b25208f3db4e081d78c1133b733c2924f96ac0f4046dd43bdb174ac02ae17ef4R148-R156)

**Testing:**

* Added unit tests for mouse hover, left-click selection, ignoring right-clicks, and ensuring selection remains unchanged when the mouse is outside menu items (`tests/unit/test_menu_system.py`).…e item selection feedback